### PR TITLE
Add empty state message for supply/demand view

### DIFF
--- a/ProjectManagerWorkbench/frmWorkbenchProjects.Designer.vb
+++ b/ProjectManagerWorkbench/frmWorkbenchProjects.Designer.vb
@@ -99,6 +99,7 @@ Partial Class frmWorkbenchProjects
         Me.sc2 = New System.Windows.Forms.SplitContainer()
         Me.lblDemandView = New System.Windows.Forms.Label()
         Me.lblShortageDescription = New System.Windows.Forms.Label()
+        Me.lblNoSupplyDemandData = New System.Windows.Forms.Label()
         Me.dgvShortages = New System.Windows.Forms.DataGridView()
         Me.SplitContainer2 = New System.Windows.Forms.SplitContainer()
         Me.dgvFurtherDetails = New System.Windows.Forms.DataGridView()
@@ -676,6 +677,7 @@ Partial Class frmWorkbenchProjects
         '
         Me.sc2.Panel1.Controls.Add(Me.lblDemandView)
         Me.sc2.Panel1.Controls.Add(Me.lblShortageDescription)
+        Me.sc2.Panel1.Controls.Add(Me.lblNoSupplyDemandData)
         Me.sc2.Panel1.Controls.Add(Me.dgvShortages)
         '
         'sc2.Panel2
@@ -708,6 +710,15 @@ Partial Class frmWorkbenchProjects
         Me.lblShortageDescription.Name = "lblShortageDescription"
         Me.lblShortageDescription.Size = New System.Drawing.Size(0, 13)
         Me.lblShortageDescription.TabIndex = 1
+
+        'lblNoSupplyDemandData
+        '
+        Me.lblNoSupplyDemandData.AutoSize = True
+        Me.lblNoSupplyDemandData.Location = New System.Drawing.Point(3, 20)
+        Me.lblNoSupplyDemandData.Name = "lblNoSupplyDemandData"
+        Me.lblNoSupplyDemandData.Size = New System.Drawing.Size(0, 13)
+        Me.lblNoSupplyDemandData.TabIndex = 3
+        Me.lblNoSupplyDemandData.Visible = False
         '
         'dgvShortages
         '
@@ -1392,6 +1403,7 @@ Partial Class frmWorkbenchProjects
     Friend WithEvents ResetColumnWidthToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents OrderToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents lblShortageDescription As System.Windows.Forms.Label
+    Friend WithEvents lblNoSupplyDemandData As System.Windows.Forms.Label
     Friend WithEvents lblDemandView As System.Windows.Forms.Label
     Friend WithEvents YourActualInvolvementToolStripMenuItem As System.Windows.Forms.ToolStripMenuItem
     Friend WithEvents lblOccurances As System.Windows.Forms.Label

--- a/ProjectManagerWorkbench/frmWorkbenchProjects.vb
+++ b/ProjectManagerWorkbench/frmWorkbenchProjects.vb
@@ -583,6 +583,15 @@ Public Class frmWorkbenchProjects
             'Me.calculateRunningNumberForSupplyDemand(dsMRPShortages, dgvShortages, True)
             'gridDisplay.formatGrid(dgvShortages, "")
 
+            If dsMRPShortages.Tables(0).Rows.Count = 0 Then
+                dgvShortages.Visible = False
+                lblNoSupplyDemandData.Text = "No supply or demand data found for this part"
+                lblNoSupplyDemandData.Visible = True
+            Else
+                lblNoSupplyDemandData.Visible = False
+                dgvShortages.Visible = True
+            End If
+
             lblShortageDescription.Text = "Supply & Demand For Part: " & itemNo & ControlChars.Tab & "    "
             'Starting On Hand Quantity:" & quantityOnHand.ToString & ControlChars.Tab & _
             '"   Ending On Hand Quantity:" & runningQuantity.ToString
@@ -702,8 +711,12 @@ Public Class frmWorkbenchProjects
         End If
 
         'Creating the label header of the supply and demand view.
-        lblShortageDescription.Text = "Supply & Demand For Part: " & strPart & ControlChars.Tab & "    Starting On Hand Quantity:" & quantityOnHand.ToString & ControlChars.Tab & _
-        "   Ending On Hand Quantity:" & runningQuantity.ToString
+        If ds.Tables(0).Rows.Count > 0 Then
+            lblShortageDescription.Text = "Supply & Demand For Part: " & strPart & ControlChars.Tab & "    Starting On Hand Quantity:" & quantityOnHand.ToString & ControlChars.Tab & _
+            "   Ending On Hand Quantity:" & runningQuantity.ToString
+        Else
+            lblShortageDescription.Text = "Supply & Demand For Part:"
+        End If
 
     End Sub
 

--- a/ProjectManagerWorkbench/frmWorkbenchProjects.vb
+++ b/ProjectManagerWorkbench/frmWorkbenchProjects.vb
@@ -589,6 +589,7 @@ Public Class frmWorkbenchProjects
                 lblNoSupplyDemandData.Visible = True
             Else
                 lblNoSupplyDemandData.Visible = False
+                lblNoSupplyDemandData.Text = String.Empty
                 dgvShortages.Visible = True
             End If
 


### PR DESCRIPTION
## Summary
- add new `lblNoSupplyDemandData` label in the designer
- hide shortages grid and show message when no data is returned
- only build the shortage description label when rows exist

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `msbuild -version` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*
- `mono --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fedc600c832cac6fe17a37348442